### PR TITLE
Handle manual operations

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -197,6 +197,11 @@ export class KwiksetHaloAccessory {
           this.platform.Characteristic.LockCurrentState,
           lockStatus,
         );
+        if (lockStatus != this.lockStates.locked) {
+          // the lock has been manually operated, so we sync LockTargetState too.
+          this.lockStates.isLocking = lockStatus;
+          this.service.updateCharacteristic(this.platform.Characteristic.LockTargetState, lockStatus);
+        }
         this.lockStates.locked = lockStatus;
       });
 


### PR DESCRIPTION
This PR fixed an issue reported in https://github.com/TreehouseFalcon/homebridge-kwikset-halo/issues/2.  Basically, when the lock is manually operated, we synchronize both LockCurrentState and LockTargetState to avoid to be stucked in "Locking.../Unlocking..." from HomeKit.

Fixes #2 